### PR TITLE
Correctly set Content-Length header

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -2,6 +2,7 @@ package gzip
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -40,8 +41,8 @@ func Gzip(level int) gin.HandlerFunc {
 		c.Header("Vary", "Accept-Encoding")
 		c.Writer = &gzipWriter{c.Writer, gz}
 		defer func() {
-			c.Header("Content-Length", "0")
 			gz.Close()
+			c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
 		}()
 		c.Next()
 	}

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -2,6 +2,7 @@ package gzip
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -39,6 +40,7 @@ func TestGzip(t *testing.T) {
 	assert.Equal(t, w.Header().Get("Vary"), "Accept-Encoding")
 	assert.NotEqual(t, w.Header().Get("Content-Length"), "0")
 	assert.NotEqual(t, w.Body.Len(), 19)
+	assert.Equal(t, fmt.Sprint(w.Body.Len()), w.Header().Get("Content-Length"))
 
 	gr, err := gzip.NewReader(w.Body)
 	assert.NoError(t, err)

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -37,7 +37,7 @@ func TestGzip(t *testing.T) {
 	assert.Equal(t, w.Code, 200)
 	assert.Equal(t, w.Header().Get("Content-Encoding"), "gzip")
 	assert.Equal(t, w.Header().Get("Vary"), "Accept-Encoding")
-	assert.Equal(t, w.Header().Get("Content-Length"), "0")
+	assert.NotEqual(t, w.Header().Get("Content-Length"), "0")
 	assert.NotEqual(t, w.Body.Len(), 19)
 
 	gr, err := gzip.NewReader(w.Body)


### PR DESCRIPTION
Set Content-Length to be the number of bytes written to the Writer rather than zero.