### PR TITLE
Fix response.Write hijack errors with Web Sockets

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -62,9 +62,12 @@ func (g *gzipWriter) Write(data []byte) (int, error) {
 }
 
 func shouldCompress(req *http.Request) bool {
-	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") ||
+		strings.Contains(req.Header.Get("Connection"), "Upgrade") {
+
 		return false
 	}
+
 	extension := filepath.Ext(req.URL.Path)
 	if len(extension) < 4 { // fast path
 		return true


### PR DESCRIPTION
Similar to https://github.com/gin-gonic/contrib/pull/71, we should probably exclude websocket endpoints from being compressed.

As of now, adding the gzip middleware as a "global" middleware on the engine will cause a `http: response.Write on hijacked connection` to be written to stderr whenever a socket is closed.