### PR TITLE
Add minimum length for responses to be gzipped

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	r := gin.Default()
-	r.Use(gzip.Gzip(gzip.DefaultCompression))
+	r.Use(gzip.Gzip(gzip.DefaultCompression, 0))
 	r.GET("/ping", func(c *gin.Context) {
 		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
 	})

--- a/gzip.go
+++ b/gzip.go
@@ -1,6 +1,7 @@
 package gzip
 
 import (
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io/ioutil"
@@ -19,7 +20,7 @@ const (
 	NoCompression      = gzip.NoCompression
 )
 
-func Gzip(level int) gin.HandlerFunc {
+func Gzip(level, minLength int) gin.HandlerFunc {
 	var gzPool sync.Pool
 	gzPool.New = func() interface{} {
 		gz, err := gzip.NewWriterLevel(ioutil.Discard, level)
@@ -37,28 +38,80 @@ func Gzip(level int) gin.HandlerFunc {
 		defer gzPool.Put(gz)
 		gz.Reset(c.Writer)
 
-		c.Header("Content-Encoding", "gzip")
-		c.Header("Vary", "Accept-Encoding")
-		c.Writer = &gzipWriter{c.Writer, gz}
-		defer func() {
-			gz.Close()
-			c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
-		}()
+		gzWriter := &gzipWriter{
+			ResponseWriter: c.Writer,
+			writer:         gz,
+			minLength:      minLength,
+		}
+
+		// Replace the context writer with a gzip writer
+		c.Writer = gzWriter
+
 		c.Next()
+
+		if gzWriter.compress {
+			// Just close and flush the gz writer
+			gz.Close()
+		} else {
+			// Discard the gz writer
+			gz.Reset(ioutil.Discard)
+
+			// Write the buffered data into the original writer
+			gzWriter.ResponseWriter.Write(gzWriter.buffer.Bytes())
+		}
+
+		// Set the content length if it's still possible
+		c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
 	}
 }
 
 type gzipWriter struct {
 	gin.ResponseWriter
 	writer *gzip.Writer
+
+	buffer    bytes.Buffer
+	minLength int
+	compress  bool
 }
 
 func (g *gzipWriter) WriteString(s string) (int, error) {
-	return g.writer.Write([]byte(s))
+	return g.Write([]byte(s))
 }
 
-func (g *gzipWriter) Write(data []byte) (int, error) {
-	return g.writer.Write(data)
+func (g *gzipWriter) Write(data []byte) (w int, err error) {
+	// If the first chunk of data is already bigger than the minimum size,
+	// set the headers and write directly to the gz writer
+	if g.compress == false && len(data) >= g.minLength {
+		g.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+		g.ResponseWriter.Header().Set("Vary", "Accept-Encoding")
+
+		g.compress = true
+	}
+
+	if !g.compress {
+		// Write the data into a buffer
+		w, err = g.buffer.Write(data)
+		if err != nil {
+			return
+		}
+
+		// If the buffer is bigger than the minimum size, set the headers and write
+		// the buffered data into the gz writer
+		if g.buffer.Len() >= g.minLength {
+			g.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+			g.ResponseWriter.Header().Set("Vary", "Accept-Encoding")
+
+			_, err = g.writer.Write(g.buffer.Bytes())
+			g.compress = true
+		}
+
+		return
+	}
+
+	// Write the data into the gz writer
+	w, err = g.writer.Write(data)
+
+	return
 }
 
 // Fix: https://github.com/mholt/caddy/issues/38


### PR DESCRIPTION
Very short responses become larger if they are gzipped. With
the minLength parameter you can define what minimum length a
response should have before it is gzipped. The response is
buffered up to the minimum length. As soon as the length of
the response becomes larger than the minimum length, the buffered
part will be written to the gzip writer and the headers will be
set accordingly. After that no more buffering will be applied.
If the response stays shorter than the minimum length, it will
stay uncompressed and no Accept-Encoding and Vary headers will
be set.