### PR TITLE
feat: customized excluded extensions and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,28 @@ func main() {
 }
 
 ```
+
+### Customized Excluded Extensions
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-contrib/gzip"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedExtensions([]string{".pdf", ".mp4"})))
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}
+```

--- a/README.md
+++ b/README.md
@@ -74,3 +74,28 @@ func main() {
 	r.Run(":8080")
 }
 ```
+
+### Customized Excluded Paths
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-contrib/gzip"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{"/api/"})))
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}
+```

--- a/gzip.go
+++ b/gzip.go
@@ -2,12 +2,6 @@ package gzip
 
 import (
 	"compress/gzip"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
-	"strings"
-	"sync"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,33 +14,7 @@ const (
 )
 
 func Gzip(level int) gin.HandlerFunc {
-	var gzPool sync.Pool
-	gzPool.New = func() interface{} {
-		gz, err := gzip.NewWriterLevel(ioutil.Discard, level)
-		if err != nil {
-			panic(err)
-		}
-		return gz
-	}
-	return func(c *gin.Context) {
-		if !shouldCompress(c.Request) {
-			return
-		}
-
-		gz := gzPool.Get().(*gzip.Writer)
-		defer gzPool.Put(gz)
-		defer gz.Reset(ioutil.Discard)
-		gz.Reset(c.Writer)
-
-		c.Header("Content-Encoding", "gzip")
-		c.Header("Vary", "Accept-Encoding")
-		c.Writer = &gzipWriter{c.Writer, gz}
-		defer func() {
-			gz.Close()
-			c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
-		}()
-		c.Next()
-	}
+	return newGzipHandler(level).Handle
 }
 
 type gzipWriter struct {
@@ -66,25 +34,4 @@ func (g *gzipWriter) Write(data []byte) (int, error) {
 func (g *gzipWriter) WriteHeader(code int) {
 	g.Header().Del("Content-Length")
 	g.ResponseWriter.WriteHeader(code)
-}
-
-func shouldCompress(req *http.Request) bool {
-	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") ||
-		strings.Contains(req.Header.Get("Connection"), "Upgrade") ||
-		strings.Contains(req.Header.Get("Content-Type"), "text/event-stream") {
-
-		return false
-	}
-
-	extension := filepath.Ext(req.URL.Path)
-	if len(extension) < 4 { // fast path
-		return true
-	}
-
-	switch extension {
-	case ".png", ".gif", ".jpeg", ".jpg":
-		return false
-	default:
-		return true
-	}
 }

--- a/gzip.go
+++ b/gzip.go
@@ -13,8 +13,8 @@ const (
 	NoCompression      = gzip.NoCompression
 )
 
-func Gzip(level int) gin.HandlerFunc {
-	return newGzipHandler(level).Handle
+func Gzip(level int, options ...Option) gin.HandlerFunc {
+	return newGzipHandler(level, options...).Handle
 }
 
 type gzipWriter struct {

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -130,6 +130,26 @@ func TestExcludedExtensions(t *testing.T) {
 	assert.Equal(t, "", w.Header().Get("Content-Length"))
 }
 
+func TestExcludedPaths(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/api/books", nil)
+	req.Header.Add("Accept-Encoding", "gzip")
+
+	router := gin.New()
+	router.Use(Gzip(DefaultCompression, WithExcludedPaths([]string{"/api/"})))
+	router.GET("/api/books", func(c *gin.Context) {
+		c.String(200, "this is books!")
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Header().Get("Content-Encoding"))
+	assert.Equal(t, "", w.Header().Get("Vary"))
+	assert.Equal(t, "this is books!", w.Body.String())
+	assert.Equal(t, "", w.Header().Get("Content-Length"))
+}
+
 func TestNoGzip(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -110,6 +110,26 @@ func TestGzipPNG(t *testing.T) {
 	assert.Equal(t, w.Body.String(), "this is a PNG!")
 }
 
+func TestExcludedExtensions(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/index.html", nil)
+	req.Header.Add("Accept-Encoding", "gzip")
+
+	router := gin.New()
+	router.Use(Gzip(DefaultCompression, WithExcludedExtensions([]string{".html"})))
+	router.GET("/index.html", func(c *gin.Context) {
+		c.String(200, "this is a HTML!")
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Header().Get("Content-Encoding"))
+	assert.Equal(t, "", w.Header().Get("Vary"))
+	assert.Equal(t, "this is a HTML!", w.Body.String())
+	assert.Equal(t, "", w.Header().Get("Content-Length"))
+}
+
 func TestNoGzip(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,73 @@
+package gzip
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+type gzipHandler struct {
+	gzPool sync.Pool
+}
+
+func newGzipHandler(level int) *gzipHandler {
+	var gzPool sync.Pool
+	gzPool.New = func() interface{} {
+		gz, err := gzip.NewWriterLevel(ioutil.Discard, level)
+		if err != nil {
+			panic(err)
+		}
+		return gz
+	}
+	handler := &gzipHandler{
+		gzPool: gzPool,
+	}
+	return handler
+}
+
+func (g *gzipHandler) Handle(c *gin.Context) {
+	if !g.shouldCompress(c.Request) {
+		return
+	}
+
+	gz := g.gzPool.Get().(*gzip.Writer)
+	defer g.gzPool.Put(gz)
+	defer gz.Reset(ioutil.Discard)
+	gz.Reset(c.Writer)
+
+	c.Header("Content-Encoding", "gzip")
+	c.Header("Vary", "Accept-Encoding")
+	c.Writer = &gzipWriter{c.Writer, gz}
+	defer func() {
+		gz.Close()
+		c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
+	}()
+	c.Next()
+}
+
+func (g *gzipHandler) shouldCompress(req *http.Request) bool {
+	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") ||
+		strings.Contains(req.Header.Get("Connection"), "Upgrade") ||
+		strings.Contains(req.Header.Get("Content-Type"), "text/event-stream") {
+
+		return false
+	}
+
+	extension := filepath.Ext(req.URL.Path)
+	if len(extension) < 4 { // fast path
+		return true
+	}
+
+	switch extension {
+	case ".png", ".gif", ".jpeg", ".jpg":
+		return false
+	default:
+		return true
+	}
+}

--- a/handler.go
+++ b/handler.go
@@ -65,5 +65,9 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 	}
 
 	extension := filepath.Ext(req.URL.Path)
-	return !g.ExcludedExtensions.Contains(extension)
+	if g.ExcludedExtensions.Contains(extension) {
+		return false
+	}
+
+	return !g.ExcludedPaths.Contains(req.URL.Path)
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,38 @@
+package gzip
+
+var (
+	DefaultExcludedExtentions = NewExcludedExtensions([]string{
+		".png", ".gif", ".jpeg", ".jpg",
+	})
+	DefaultOptions = &Options{
+		ExcludedExtensions: DefaultExcludedExtentions,
+	}
+)
+
+type Options struct {
+	ExcludedExtensions ExcludedExtensions
+}
+
+type Option func(*Options)
+
+func WithExcludedExtensions(args []string) Option {
+	return func(o *Options) {
+		o.ExcludedExtensions = NewExcludedExtensions(args)
+	}
+}
+
+// Using map for better lookup performance
+type ExcludedExtensions map[string]bool
+
+func NewExcludedExtensions(extensions []string) ExcludedExtensions {
+	res := make(ExcludedExtensions)
+	for _, e := range extensions {
+		res[e] = true
+	}
+	return res
+}
+
+func (e ExcludedExtensions) Contains(target string) bool {
+	_, ok := e[target]
+	return ok
+}

--- a/options.go
+++ b/options.go
@@ -1,5 +1,9 @@
 package gzip
 
+import (
+	"strings"
+)
+
 var (
 	DefaultExcludedExtentions = NewExcludedExtensions([]string{
 		".png", ".gif", ".jpeg", ".jpg",
@@ -11,6 +15,7 @@ var (
 
 type Options struct {
 	ExcludedExtensions ExcludedExtensions
+	ExcludedPaths      ExcludedPaths
 }
 
 type Option func(*Options)
@@ -18,6 +23,12 @@ type Option func(*Options)
 func WithExcludedExtensions(args []string) Option {
 	return func(o *Options) {
 		o.ExcludedExtensions = NewExcludedExtensions(args)
+	}
+}
+
+func WithExcludedPaths(args []string) Option {
+	return func(o *Options) {
+		o.ExcludedPaths = NewExcludedPaths(args)
 	}
 }
 
@@ -35,4 +46,19 @@ func NewExcludedExtensions(extensions []string) ExcludedExtensions {
 func (e ExcludedExtensions) Contains(target string) bool {
 	_, ok := e[target]
 	return ok
+}
+
+type ExcludedPaths []string
+
+func NewExcludedPaths(paths []string) ExcludedPaths {
+	return ExcludedPaths(paths)
+}
+
+func (e ExcludedPaths) Contains(requestURI string) bool {
+	for _, path := range e {
+		if strings.HasPrefix(requestURI, path) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
I guess it would be better to support some customized excluded options, e.g.
- Extensions
- Paths

I also changed the method of checking excluded extensions - use map for a better lookup performance.

And I also make two more test cases for the excluded options.