### PR TITLE
feat : excluede paths by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,30 @@ func main() {
 	r.Run(":8080")
 }
 ```
+
+
+Customized Excluded Paths
+
+```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-contrib/gzip"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPathsRegexs([]string{".*"})))
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}
+```

--- a/handler.go
+++ b/handler.go
@@ -72,6 +72,11 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 	if g.ExcludedExtensions.Contains(extension) {
 		return false
 	}
-
-	return !g.ExcludedPaths.Contains(req.URL.Path) && !g.ExcludedPathesRegexs.Contains(req.URL.Path)
+	if !g.ExcludedPaths.Contains(req.URL.Path) {
+		return false
+	}
+	if !g.ExcludedPathesRegexs.Contains(req.URL.Path) {
+		return false
+	}
+	return true
 }

--- a/handler.go
+++ b/handler.go
@@ -73,11 +73,10 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 		return false
 	}
 
-	if !g.ExcludedPaths.Contains(req.URL.Path) {
+	if g.ExcludedPaths.Contains(req.URL.Path) {
 		return false
 	}
-
-	if !g.ExcludedPathesRegexs.Contains(req.URL.Path) {
+	if g.ExcludedPathesRegexs.Contains(req.URL.Path) {
 		return false
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -73,5 +73,5 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 		return false
 	}
 
-	return !g.ExcludedPaths.Contains(req.URL.Path)
+	return !g.ExcludedPaths.Contains(req.URL.Path) && !g.ExcludedPathesRegexs.Contains(req.URL.Path)
 }

--- a/handler.go
+++ b/handler.go
@@ -72,11 +72,14 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 	if g.ExcludedExtensions.Contains(extension) {
 		return false
 	}
+
 	if !g.ExcludedPaths.Contains(req.URL.Path) {
 		return false
 	}
+
 	if !g.ExcludedPathesRegexs.Contains(req.URL.Path) {
 		return false
 	}
+
 	return true
 }

--- a/options.go
+++ b/options.go
@@ -3,9 +3,8 @@ package gzip
 import (
 	"compress/gzip"
 	"net/http"
-	"strings"
-
 	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,6 +38,7 @@ func WithExcludedPaths(args []string) Option {
 		o.ExcludedPaths = NewExcludedPaths(args)
 	}
 }
+
 func WithExcludedPathsRegexs(args []string) Option {
 	return func(o *Options) {
 		o.ExcludedPathesRegexs = NewExcludedPathesRegexs(args)
@@ -91,6 +91,7 @@ func NewExcludedPathesRegexs(regexs []string) ExcludedPathesRegexs {
 	}
 	return result
 }
+
 func (e ExcludedPathesRegexs) Contains(requestURI string) bool {
 	for _, reg := range e {
 		if reg.MatchString(requestURI) {


### PR DESCRIPTION
Proposal
Allow regular expressions to exclude paths.
Gin can specify parameters in the URL.
In this case, the action name may be specified below the parameter.
The current exclusion doesn't allow you to specify a lower parameter, so I'd like to add it.
exp: 
````
// In the case of export_zip, i don't want to do gzip.
r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPathsRegexs([]string{".*export_zip"})))
r.GET("/ping/:variable/export_zip",func(c *gin.Context){ })
r.GET("/ping/:variable/export_text",func(c *gin.Context){ })
````

