### PR TITLE
Introduce `MatchSupportedRequestFn` option for more granular decision making process to compress a response

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -67,17 +67,16 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 		return false
 	}
 
-	extension := filepath.Ext(req.URL.Path)
-	if g.ExcludedExtensions.Contains(extension) {
-		return false
+	if g.MatchSupportedRequestFn != nil {
+		if ok, supported := g.MatchSupportedRequestFn(req); ok {
+			return supported
+		}
 	}
 
-	if g.ExcludedPaths.Contains(req.URL.Path) {
-		return false
-	}
-	if g.ExcludedPathesRegexs.Contains(req.URL.Path) {
-		return false
-	}
+	return !g.isPathExcluded(req.URL.Path)
+}
 
-	return true
+func (g *gzipHandler) isPathExcluded(path string) bool {
+	extension := filepath.Ext(path)
+	return g.ExcludedExtensions.Contains(extension) || g.ExcludedPaths.Contains(path) || g.ExcludedPathesRegexs.Contains(path)
 }

--- a/options.go
+++ b/options.go
@@ -23,6 +23,9 @@ type Options struct {
 	ExcludedPaths        ExcludedPaths
 	ExcludedPathesRegexs ExcludedPathesRegexs
 	DecompressFn         func(c *gin.Context)
+	// MatchSupportedRequestFn has a precedence over Excluded* options.
+	// `ok' value is to stop other checks and treat `supported` value as if the request should be compressed or not.
+	MatchSupportedRequestFn func(req *http.Request) (ok bool, supported bool)
 }
 
 type Option func(*Options)
@@ -48,6 +51,12 @@ func WithExcludedPathsRegexs(args []string) Option {
 func WithDecompressFn(decompressFn func(c *gin.Context)) Option {
 	return func(o *Options) {
 		o.DecompressFn = decompressFn
+	}
+}
+
+func WithMatchSupportedRequestFn(matchSupportedRequestFn func(req *http.Request) (bool, bool)) Option {
+	return func(o *Options) {
+		o.MatchSupportedRequestFn = matchSupportedRequestFn
 	}
 }
 


### PR DESCRIPTION
## Rationale

`WithMatchSupportedRequestFn` option is introduced. This allows to make a decision about response compression basing on a combination of other headers and values from a request (like https://github.com/gin-contrib/gzip/issues/42).

## Changes

- No breaking changes in API for existing clients
- No breaking changes in behavior for existing clients
- `WithMatchSupportedRequestFn()` accepts a function with a signature: `func(req *http.Request) (ok bool, supported bool)`. The first returned `ok` value is a marker that no other checks if a compression is excluded should be applied: `supported` is a decision for compression.
- `MatchSupportedRequestFn` has a precedence over `Excluded{Extensions,Paths,PathesRegexs}` lists. If `ok` is `false`, the other (= the mentioned before) exclusion rules are applied.

## Notes

- `http.Request` is used intentionally instead of, say, `gin.Context`. The goal is to have a safe limited interface. 
- In general, existing exclusion lists could be re-implemented in the future through the newly added interface. 