### PR TITLE
chore: discard gzip footer when empty body

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -54,6 +54,10 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 	c.Header("Vary", "Accept-Encoding")
 	c.Writer = &gzipWriter{c.Writer, gz}
 	defer func() {
+		if c.Writer.Size() < 0 {
+			// do not write gzip footer when nothing is written to the response body
+			gz.Reset(io.Discard)
+		}
 		gz.Close()
 		c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
 	}()


### PR DESCRIPTION
fixed #46 

Before gzip writer close it is checked if anything has been written to the writer. If not the writer is replaced by discard one what directs gzip footer not to be written in to a response body. 