### PR TITLE
gzip decompress-only supports

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -41,7 +41,7 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 		fn(c)
 	}
 
-	if !g.shouldCompress(c.Request) {
+	if g.DecompressOnly || !g.shouldCompress(c.Request) {
 		return
 	}
 

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	ExcludedPaths        ExcludedPaths
 	ExcludedPathesRegexs ExcludedPathesRegexs
 	DecompressFn         func(c *gin.Context)
+	DecompressOnly       bool
 }
 
 type Option func(*Options)
@@ -48,6 +49,13 @@ func WithExcludedPathsRegexs(args []string) Option {
 func WithDecompressFn(decompressFn func(c *gin.Context)) Option {
 	return func(o *Options) {
 		o.DecompressFn = decompressFn
+	}
+}
+
+// disable compression, only decompress incoming request
+func WithDecompressOnly(decompressOnly bool) Option {
+	return func(o *Options) {
+		o.DecompressOnly = decompressOnly
 	}
 }
 


### PR DESCRIPTION
Hi, my backend service runs behind Caddy (which has gzip and zstd compression enabled).

So I want to use `gin-contrib/gzip` to decompress incoming gzip requests but not touch the responses.

## How to use

use `gzip.WithDecompressOnly(true)` option.

```go
r.Use(gzip.Gzip(gzip.NoCompression, gzip.WithDecompressOnly(true), gzip.WithDecompressFn(gzip.DefaultDecompressHandle)))
```

---

related: #32