### PR TITLE
fix: use `Header().Add` instead of `Header()` for setting `Vary` header

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -12,10 +12,14 @@ import (
 
 func main() {
 	r := gin.Default()
-	r.Use(gzip.Gzip(
-		gzip.DefaultCompression,
-		gzip.WithExcludedPaths([]string{"/ping2"}),
-	))
+	r.Use(
+		func(c *gin.Context) {
+			c.Writer.Header().Add("Vary", "Origin")
+		},
+		gzip.Gzip(
+			gzip.DefaultCompression,
+			gzip.WithExcludedPaths([]string{"/ping2"}),
+		))
 	r.Use(func(c *gin.Context) {
 		log.Println("Request received")
 		c.Next()

--- a/handler.go
+++ b/handler.go
@@ -85,7 +85,7 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 	gz.Reset(c.Writer)
 
 	c.Header(headerContentEncoding, "gzip")
-	c.Header(headerVary, headerAcceptEncoding)
+	c.Writer.Header().Add(headerVary, headerAcceptEncoding)
 	c.Writer = &gzipWriter{c.Writer, gz}
 	defer func() {
 		if c.Writer.Size() < 0 {


### PR DESCRIPTION
- Modify middleware to add "Vary: Origin" header before applying gzip compression
- Add a new test to verify the "Vary" header is correctly set and gzip compression is applied
- Update handler to use `Header().Add` instead of `Header()` for setting "Vary" header

fix #49 