### PR TITLE
refactor: improve error handling and resource management in gzip utils

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -48,10 +48,7 @@ func newGzipHandler(level int, opts ...Option) *gzipHandler {
 		config: cfg,
 		gzPool: sync.Pool{
 			New: func() interface{} {
-				gz, err := gzip.NewWriterLevel(io.Discard, level)
-				if err != nil {
-					panic(err)
-				}
+				gz, _ := gzip.NewWriterLevel(io.Discard, level)
 				return gz
 			},
 		},
@@ -79,8 +76,8 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 
 	gz := g.gzPool.Get().(*gzip.Writer)
 	defer func() {
-		g.gzPool.Put(gz)
 		gz.Reset(io.Discard)
+		g.gzPool.Put(gz)
 	}()
 	gz.Reset(c.Writer)
 


### PR DESCRIPTION
- Simplify error handling by ignoring the error from `gzip.NewWriterLevel`
- Reorder `gzPool.Put(gz)` after `gz.Reset(io.Discard)` in the defer function

fixed https://github.com/gin-contrib/gzip/issues/88