### PR TITLE
Add WithMinLength option to control when responses are gzipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,48 @@ func main() {
 }
 ```
 
+### Compress only when response meets minimum byte size
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-contrib/gzip"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithMinLength(2048)))
+	r.GET("/ping", func(c *gin.Context) {
+		sizeStr := c.Query("size")
+		size, _ := strconv.Atoi(sizeStr)
+		c.String(http.StatusOK, strings.Repeat("a", size))
+	})
+
+	// Listen and Server in 0.0.0.0:8080
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+Test with curl:
+```bash
+curl -i --compressed 'http://localhost:8080/ping?size=2047'
+curl -i --compressed 'http://localhost:8080/ping?size=2048'
+```
+
+Notes:
+- If a "Content-Length" header is set, that will be used to determine whether to compress based on the given min length.
+- If no "Content-Length" header is set, a buffer is used to temporarily store writes until the min length is met or the request completes.
+  - Setting a high min length will result in more buffering (2048 bytes is a recommended default for most cases)
+  - The handler performs optimizations to avoid unnecessary operations, such as testing if `len(data)` exceeds min length before writing to the buffer, and reusing buffers between requests.
+
 ### Customized Excluded Extensions
 
 ```go

--- a/options.go
+++ b/options.go
@@ -47,6 +47,7 @@ type config struct {
 	decompressFn           func(c *gin.Context)
 	decompressOnly         bool
 	customShouldCompressFn func(c *gin.Context) bool
+	minLength              int
 }
 
 // WithExcludedExtensions returns an Option that sets the ExcludedExtensions field of the Options struct.
@@ -114,6 +115,32 @@ func WithDecompressOnly() Option {
 func WithCustomShouldCompressFn(fn func(c *gin.Context) bool) Option {
 	return optionFunc(func(o *config) {
 		o.customShouldCompressFn = fn
+	})
+}
+
+// WithMinLength returns an Option that sets the minLength field of the Options struct.
+// Parameters:
+//   - minLength: int - The minimum length of the response body (in bytes) to trigger gzip compression.
+//     If the response body is smaller than this length, it will not be compressed.
+//     This option is useful for avoiding the overhead of compression on small responses, especially since gzip
+//     compression actually increases the size of small responses. 2048 is a recommended value for most cases.
+//     The minLength value must be non-negative; negative values will cause undefined behavior.
+//
+// Note that specifying this option does not override other options. If a path has been excluded (eg through
+// WithExcludedPaths), it will continue to be excluded.
+//
+// Returns:
+//   - Option - An option that sets the MinLength field of the Options struct.
+//
+// Example:
+//
+//	router.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithMinLength(2048)))
+func WithMinLength(minLength int) Option {
+	if minLength < 0 {
+		panic("minLength must be non-negative")
+	}
+	return optionFunc(func(o *config) {
+		o.minLength = minLength
 	})
 }
 


### PR DESCRIPTION
Enables conditional compression based on response size. The response is stored in a temporary buffer within the gzipWriter if it does not meet the provided limit (required in case the server executes additional writes to the response later in its handler control flow). When the handler finally returns, we check whether the limit was met. If not, the buffer contents are written directly to the underlying gin Writer with no gzip compression.

Credit to #20 for the main implementation details

Closes #18
Closes #20
Closes #34
Closes #81 
Resolves part of #70