### PR TITLE
Remove 'c.Next()' from DefaultDecompressHandle() to prevent breaking response compression in Handle()

### DIFF
--- a/options.go
+++ b/options.go
@@ -265,6 +265,4 @@ func DefaultDecompressHandle(c *gin.Context) {
 
 	c.Request.Header.Del("Content-Encoding")
 	c.Request.Header.Del("Content-Length")
-
-	c.Next()
 }


### PR DESCRIPTION
Fixes https://github.com/gin-contrib/gzip/issues/108