### PR TITLE
#98 Bug/incorrect response code for empty body

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -89,6 +89,10 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 		if c.Writer.Size() < 0 {
 			// do not write gzip footer when nothing is written to the response body
 			gz.Reset(io.Discard)
+
+			// revert back to the original gin ResponseWriter to allow gin to handle the empty response (i.e. 404)
+			c.Writer = c.Writer.(*gzipWriter).ResponseWriter
+			c.Header(headerContentEncoding, "")
 		}
 		_ = gz.Close()
 		if c.Writer.Size() > -1 {

--- a/handler_test.go
+++ b/handler_test.go
@@ -52,7 +52,7 @@ func TestHandleGzip(t *testing.T) {
 			name:                    "Bad path, with compression",
 			path:                    "/bad-path",
 			acceptEncoding:          "gzip",
-			expectedContentEncoding: "gzip",
+			expectedContentEncoding: "",
 			expectedBody:            "404 page not found",
 			expectedStatus:          http.StatusNotFound,
 		},


### PR DESCRIPTION
This resolves an issue where if the route is not found the gzip lib returns 200 status code if nothing writes to the body.

I considered a couple of approaches:

- Conditionally write the headers during the defer, this overrides the default Gin behaviour which is not desirable
  - This has a bunch of edge cases like if another middleware is doing something with 404 bodies
- Conditionally ignore the gzip middleware on 404 status codes or set to do not compress
  - If there is response content by another middleware theres no reason why we can't compress it 
-  Conditionally replace the gzip writer with the original gin writer if it hasn't already been used
  - Seemed to be the most sensible if we are not going to use the gzip writer we can just put the gin writer back in