### PR TITLE
fix(body): fix data corruption during decompression (#108)

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -7,11 +7,43 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
+
+// ClosedReader wraps an io.Reader to read data by chunks
+// and returns an error if the reader is prematurely closed.
+type ClosedReader struct {
+	reader    io.Reader
+	chunkSize int
+	closed    bool
+}
+
+func NewClosedReader(reader io.Reader, chunkSize int) io.Reader {
+	return &ClosedReader{
+		reader:    reader,
+		chunkSize: chunkSize,
+	}
+}
+
+func (r *ClosedReader) Read(b []byte) (n int, err error) {
+	if r.closed {
+		return 0, io.EOF
+	}
+
+	return r.reader.Read(b[0 : min(r.chunkSize, len(b))-1])
+}
+
+func (r *ClosedReader) Close() (err error) {
+	r.closed = true
+	if closer, ok := r.reader.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
 
 func TestHandleGzip(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -97,7 +129,104 @@ func TestHandleDecompressGzip(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Header().Get("Content-Encoding"))
 	assert.Equal(t, "ok", w.Body.String())
+}
+
+func TestHandleDecompressGzipCompressResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name                    string
+		acceptEncoding          string
+		gzipIterations          uint
+		expectedContentEncoding string
+		expectedBody            string
+	}{
+		{
+			name:                    "decompress with gzip accept-encoding should compress response",
+			acceptEncoding:          gzipEncoding,
+			gzipIterations:          1,
+			expectedContentEncoding: gzipEncoding,
+			expectedBody:            "Gzip Test Response",
+		},
+		{
+			name:                    "decompress without gzip accept-encoding should not compress response",
+			acceptEncoding:          "",
+			gzipIterations:          1,
+			expectedContentEncoding: "",
+			expectedBody:            "Gzip Test Response",
+		},
+		{
+			name:                    "decompress multi compressed request with gzip accept-encoding should compress response",
+			acceptEncoding:          gzipEncoding,
+			gzipIterations:          3,
+			expectedContentEncoding: gzipEncoding,
+			expectedBody:            "Gzip Test Response",
+		},
+		{
+			name:                    "decompress multi compressed request without gzip accept-encoding should not compress response",
+			acceptEncoding:          "",
+			gzipIterations:          3,
+			expectedContentEncoding: "",
+			expectedBody:            "Gzip Test Response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.Default()
+			router.Use(Gzip(DefaultCompression, WithDecompressFn(DefaultDecompressHandle)))
+			router.POST("/", func(c *gin.Context) {
+				data, err := c.GetRawData()
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedBody, string(data))
+				c.String(http.StatusOK, tt.expectedBody)
+			})
+
+			data := []byte(tt.expectedBody)
+			headers := []string{}
+			for range tt.gzipIterations {
+				headers = append(headers, gzipEncoding)
+				buf := &bytes.Buffer{}
+				gz, _ := gzip.NewWriterLevel(buf, gzip.DefaultCompression)
+				if _, err := gz.Write(data); err != nil {
+					gz.Close()
+					t.Fatal(err)
+				}
+				gz.Close()
+				data = buf.Bytes()
+			}
+
+			// Simulate a buffering network request
+			// It permits to illustrate the behaviour
+			// when DefaultDecompressHandle closes an half read request
+			reader := NewClosedReader(bytes.NewReader(data), len(data)/2)
+
+			req, _ := http.NewRequestWithContext(context.Background(), "POST", "/", reader)
+			req.Header.Add("Content-Encoding", strings.Join(headers, ", "))
+			if tt.acceptEncoding != "" {
+				req.Header.Set(headerAcceptEncoding, tt.acceptEncoding)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedContentEncoding, w.Header().Get("Content-Encoding"))
+
+			if tt.expectedContentEncoding == gzipEncoding {
+				gr, err := gzip.NewReader(w.Body)
+				assert.NoError(t, err)
+				defer gr.Close()
+
+				body, _ := io.ReadAll(gr)
+				assert.Equal(t, tt.expectedBody, string(body))
+			} else {
+				assert.Equal(t, tt.expectedBody, w.Body.String())
+			}
+		})
+	}
 }
 
 func TestHandle404NoCompression(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -247,14 +247,13 @@ func DefaultDecompressHandle(c *gin.Context) {
 
 	contentEncodingField := strings.Split(strings.ToLower(c.GetHeader("Content-Encoding")), ",")
 	if len(contentEncodingField) == 0 { // nothing to decompress
-		c.Next()
-
 		return
 	}
 
 	toClose := make([]io.Closer, 0, len(contentEncodingField))
 	defer func() {
-		for i := len(toClose); i > 0; i-- {
+		// Close readers in reverse order, except the top level one
+		for i := len(toClose); i > 1; i-- {
 			toClose[i-1].Close()
 		}
 	}()
@@ -292,6 +291,4 @@ func DefaultDecompressHandle(c *gin.Context) {
 
 	c.Request.Header.Del("Content-Encoding")
 	c.Request.Header.Del("Content-Length")
-
-	c.Next()
 }


### PR DESCRIPTION
* prevent mixed response containing plain text and gzipped data, due to c.Next() calls in DefaultDecompressHandle.
* prevent EOF while decompressing a buffered request body. This is easily triggered whith long payloads requiring several reads. The issue is that the defered close calls are performed on all the readers, including the top level one, and can close the request before the whole data is read. A workaround consists in not closing the top level reader.