### PR TITLE
fix: preserve panic status code by not flushing an empty buffer

### DIFF
--- a/gzip_test.go
+++ b/gzip_test.go
@@ -715,3 +715,43 @@ http_requests_total{method="get",status="400"} 3 1395066363000`
 		assert.Equal(t, prometheusData, w.Body.String(), "Uncompressed metrics should match original content")
 	}
 }
+
+// TestPanicStatusCode reproduces issue #140: when a handler panics, gin's
+// Recovery middleware sets a 500 status, but the gzip middleware used to flush
+// the response header with the default 200 before Recovery could run, so the
+// client saw 200 instead of 500.
+func TestPanicStatusCode(t *testing.T) {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(Gzip(DefaultCompression))
+	router.GET("/panic", func(_ *gin.Context) {
+		panic("boom")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/panic", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"panic should yield 500, not the default 200")
+}
+
+// TestEmptyBodyStatusPreserved guards the fix for #140: a handler that sets an
+// explicit status with no body must still send that status (the empty buffer is
+// skipped, not written with a premature default status).
+func TestEmptyBodyStatusPreserved(t *testing.T) {
+	router := gin.New()
+	router.Use(Gzip(DefaultCompression))
+	router.GET("/no-content", func(c *gin.Context) {
+		c.Status(http.StatusNoContent) // 204, no body
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/no-content", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
+}

--- a/handler.go
+++ b/handler.go
@@ -102,8 +102,15 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 			// internal buffer which should now be written to the response writer directly
 			gw.Header().Del(headerContentEncoding)
 			gw.Header().Del(headerVary)
-			// must refer directly to embedded writer since c.Writer gets overridden
-			_, _ = gw.ResponseWriter.Write(gw.buffer.Bytes())
+			// Only flush the buffer when it actually holds data. Writing an empty
+			// buffer would force the response header to be committed with the
+			// current status. During panic unwinding this defer runs before gin's
+			// Recovery middleware sets 500, so an unconditional write would leak a
+			// premature 200 header and prevent Recovery from overriding it (#140).
+			if gw.buffer.Len() > 0 {
+				// must refer directly to embedded writer since c.Writer gets overridden
+				_, _ = gw.ResponseWriter.Write(gw.buffer.Bytes())
+			}
 			gz.Reset(io.Discard)
 		case c.Writer.Size() < 0:
 			// do not write gzip footer when nothing is written to the response body


### PR DESCRIPTION
Since v1.2.6, a panic in a handler wrapped by the gzip middleware resulted in a `200` status being sent to the client instead of the `500` set by gin's Recovery middleware.

## Root cause
When compression was not triggered, the deferred cleanup in `Handle` unconditionally wrote the internal buffer to the underlying `ResponseWriter`. During panic unwinding this defer runs **before** Recovery sets the status, so writing an empty buffer committed the response header with the default `200`, and Recovery could no longer override it:

```
[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 200 with 500
```

## Fix
Only flush the buffer when it actually contains data, so an empty buffer no longer forces a premature header write.

## Tests
- `TestPanicStatusCode` — a panicking handler now yields `500` (fails on the previous code, which returned `200`).
- `TestEmptyBodyStatusPreserved` — a handler that sets an explicit status with no body still sends that status.

Fixes #140

> Note: the repo's `TestDecompressGzip` / `TestDecompressOnly` tests appear to be flaky/order-dependent on `master` independent of this change; happy to look into that separately if useful.