### PR TITLE
feat: add WithExcludedContentTypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,37 @@ func main() {
 }
 ```
 
+### Customized Excluded Content Types
+
+Skip compression based on the response `Content-Type`. Each argument is matched
+as a prefix against the response media type (case-insensitively), so `"image/"`
+excludes every image type while `"image/jpeg"` excludes only JPEGs.
+
+```go
+package main
+
+import (
+  "log"
+  "net/http"
+
+  "github.com/gin-contrib/gzip"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  r := gin.Default()
+  r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedContentTypes([]string{"image/", "video/"})))
+  r.GET("/image", func(c *gin.Context) {
+    c.Data(http.StatusOK, "image/jpeg", someJPEGBytes)
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  if err := r.Run(":8080"); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
 ### Server Push
 
 ```go

--- a/gzip.go
+++ b/gzip.go
@@ -30,6 +30,8 @@ type gzipWriter struct {
 	writer        *gzip.Writer
 	statusWritten bool
 	status        int
+	// excludedContentTypes holds response Content-Type prefixes that must not be compressed
+	excludedContentTypes ExcludedContentTypes
 	// minLength is the minimum length of the response body (in bytes) to enable compression
 	minLength int
 	// shouldCompress indicates whether the minimum length for compression has been met
@@ -53,6 +55,12 @@ func (g *gzipWriter) Write(data []byte) (int, error) {
 	// For error responses (4xx, 5xx), don't compress
 	// Always check the current status, even if WriteHeader was called
 	if g.status >= 400 {
+		g.removeGzipHeaders()
+		return g.ResponseWriter.Write(data)
+	}
+
+	// If the response Content-Type is excluded, pass through without compression.
+	if g.excludedContentTypes.Contains(g.Header().Get("Content-Type")) {
 		g.removeGzipHeaders()
 		return g.ResponseWriter.Write(data)
 	}

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -715,3 +715,63 @@ http_requests_total{method="get",status="400"} 3 1395066363000`
 		assert.Equal(t, prometheusData, w.Body.String(), "Uncompressed metrics should match original content")
 	}
 }
+
+// TestExcludedContentTypes verifies that responses whose Content-Type matches a
+// configured excluded prefix are passed through without gzip compression, while
+// other responses are still compressed (issue #42).
+func TestExcludedContentTypes(t *testing.T) {
+	tests := []struct {
+		name            string
+		contentType     string
+		body            string
+		wantCompression bool
+	}{
+		{"excluded exact image type", "image/jpeg", "\xff\xd8\xff fake jpeg bytes padded long enough", false},
+		{"excluded image family via prefix", "image/png", "\x89PNG fake png bytes padded to be long", false},
+		{"excluded with charset parameter", "image/svg+xml; charset=utf-8", "<svg>svg markup, long enough</svg>", false},
+		{"not excluded text type is compressed", "text/plain", strings.Repeat("compress me ", 20), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(Gzip(DefaultCompression, WithExcludedContentTypes([]string{"image/"})))
+			router.GET("/resource", func(c *gin.Context) {
+				c.Data(http.StatusOK, tt.contentType, []byte(tt.body))
+			})
+
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "/resource", nil)
+			req.Header.Add(headerAcceptEncoding, "gzip")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			if tt.wantCompression {
+				assert.Equal(t, "gzip", w.Header().Get(headerContentEncoding))
+				gr, err := gzip.NewReader(w.Body)
+				require.NoError(t, err)
+				defer gr.Close()
+				body, err := io.ReadAll(gr)
+				require.NoError(t, err)
+				assert.Equal(t, tt.body, string(body))
+			} else {
+				assert.Empty(t, w.Header().Get(headerContentEncoding))
+				assert.Equal(t, tt.body, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestExcludedContentTypesContains covers the prefix, case-insensitive and
+// parameter-stripping matching behavior of ExcludedContentTypes.
+func TestExcludedContentTypesContains(t *testing.T) {
+	e := NewExcludedContentTypes([]string{"image/", "Application/PDF"})
+
+	assert.True(t, e.Contains("image/jpeg"))
+	assert.True(t, e.Contains("image/png; charset=binary"))
+	assert.True(t, e.Contains("IMAGE/GIF")) // case-insensitive
+	assert.True(t, e.Contains("application/pdf"))
+	assert.False(t, e.Contains("text/plain"))
+	assert.False(t, e.Contains("")) // empty header
+	assert.False(t, ExcludedContentTypes(nil).Contains("image/jpeg"))
+}

--- a/handler.go
+++ b/handler.go
@@ -85,9 +85,10 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 		c.Header("ETag", "W/"+originalEtag)
 	}
 	gw := &gzipWriter{
-		ResponseWriter: c.Writer,
-		writer:         gz,
-		minLength:      g.minLength,
+		ResponseWriter:       c.Writer,
+		writer:               gz,
+		minLength:            g.minLength,
+		excludedContentTypes: g.excludedContentTypes,
 	}
 	c.Writer = gw
 	defer func() {

--- a/options.go
+++ b/options.go
@@ -44,6 +44,7 @@ type config struct {
 	excludedExtensions     ExcludedExtensions
 	excludedPaths          ExcludedPaths
 	excludedPathesRegexs   ExcludedPathesRegexs
+	excludedContentTypes   ExcludedContentTypes
 	decompressFn           func(c *gin.Context)
 	decompressOnly         bool
 	customShouldCompressFn func(c *gin.Context) bool
@@ -74,6 +75,29 @@ func WithExcludedPaths(args []string) Option {
 func WithExcludedPathsRegexs(args []string) Option {
 	return optionFunc(func(o *config) {
 		o.excludedPathesRegexs = NewExcludedPathesRegexs(args)
+	})
+}
+
+// WithExcludedContentTypes returns an Option that excludes responses from gzip
+// compression based on their Content-Type response header.
+//
+// Each argument is matched as a prefix against the response media type (the part
+// of the Content-Type header before any ";" parameters, compared
+// case-insensitively). This makes it possible to exclude a whole family of types
+// (e.g. "image/" for every image) or a single type (e.g. "image/jpeg").
+//
+// Note: the match relies on the Content-Type header set by the handler. If a
+// handler writes a body without setting Content-Type, no exclusion is applied.
+//
+// Parameters:
+//   - args: []string - Content-Type prefixes to exclude from gzip compression.
+//
+// Example:
+//
+//	router.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedContentTypes([]string{"image/", "video/"})))
+func WithExcludedContentTypes(args []string) Option {
+	return optionFunc(func(o *config) {
+		o.excludedContentTypes = NewExcludedContentTypes(args)
 	})
 }
 
@@ -170,6 +194,50 @@ func NewExcludedExtensions(extensions []string) ExcludedExtensions {
 func (e ExcludedExtensions) Contains(target string) bool {
 	_, ok := e[target]
 	return ok
+}
+
+// ExcludedContentTypes holds the response Content-Type prefixes that should be
+// excluded from gzip compression. Entries are stored lowercased for
+// case-insensitive matching.
+type ExcludedContentTypes []string
+
+// NewExcludedContentTypes creates a new ExcludedContentTypes from a slice of
+// Content-Type prefixes. Each entry is lowercased so matching is
+// case-insensitive.
+//
+// Parameters:
+//   - contentTypes: []string - A slice of Content-Type prefixes to exclude.
+//
+// Returns:
+//   - ExcludedContentTypes - The normalized set of excluded Content-Type prefixes.
+func NewExcludedContentTypes(contentTypes []string) ExcludedContentTypes {
+	res := make(ExcludedContentTypes, len(contentTypes))
+	for i, ct := range contentTypes {
+		res[i] = strings.ToLower(strings.TrimSpace(ct))
+	}
+	return res
+}
+
+// Contains reports whether the given Content-Type header value matches any of
+// the excluded prefixes. The media type (the part before any ";" parameters) is
+// compared case-insensitively against each excluded prefix.
+//
+// Parameters:
+//   - contentType: string - The response Content-Type header value to check.
+//
+// Returns:
+//   - bool - True if the response should be excluded from compression.
+func (e ExcludedContentTypes) Contains(contentType string) bool {
+	if len(e) == 0 || contentType == "" {
+		return false
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+	for _, ct := range e {
+		if ct != "" && strings.HasPrefix(mediaType, ct) {
+			return true
+		}
+	}
+	return false
 }
 
 type ExcludedPaths []string


### PR DESCRIPTION
Allow skipping gzip compression based on the response `Content-Type`, so already-compressed payloads such as images or video can be served uncompressed.

## Why
Requested in #42: an API that returns images (e.g. `image/jpeg`) has no benefit from gzip and wastes CPU. There were options to exclude by path/extension, but not by response content type.

## Design
`Content-Type` is a **response** header, only known once the handler runs, so the check is performed in `gzipWriter.Write` alongside the existing status and `Content-Encoding` passthrough logic — not in the request-time `shouldCompress` decision.

Each configured value is matched as a **case-insensitive prefix** against the response media type (the part before any `;` parameters), so `"image/"` excludes every image type while `"image/jpeg"` excludes only JPEGs.

```go
r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedContentTypes([]string{"image/", "video/"})))
```

## Changes
- New `WithExcludedContentTypes([]string)` option.
- New `ExcludedContentTypes` type with `NewExcludedContentTypes` / `Contains`.
- The exclusion check in `gzipWriter.Write`.
- Tests (`TestExcludedContentTypes`, `TestExcludedContentTypesContains`) and a README example.

Closes #42

> Note: the repo's `TestDecompressGzip` / `TestDecompressOnly` tests appear to be flaky/order-dependent on `master` independent of this change.