### PR TITLE
test(static): make gzip size assertion robust on Go 1.27

### DIFF
--- a/static_test.go
+++ b/static_test.go
@@ -1,11 +1,14 @@
 package gzip
 
 import (
+	"compress/gzip"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -19,10 +22,12 @@ func TestStaticFileWithGzip(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	// Create a test file
+	// Create a test file. The content is repeated so that it is large and
+	// redundant enough for deflate to emit a compressed block; very short
+	// inputs may legitimately be stored uncompressed by newer Go versions.
 	testFile := filepath.Join(tmpDir, "test.txt")
-	testContent := "This is a test file for static gzip compression testing. " +
-		"It should be long enough to trigger gzip compression."
+	testContent := strings.Repeat("This is a test file for static gzip compression testing. "+
+		"It should be long enough to trigger gzip compression. ", 10)
 	err = os.WriteFile(testFile, []byte(testContent), 0o600)
 	require.NoError(t, err)
 
@@ -49,6 +54,14 @@ func TestStaticFileWithGzip(t *testing.T) {
 
 	// The compressed content should be smaller than original
 	assert.Less(t, w.Body.Len(), len(testContent), "Compressed content should be smaller")
+
+	// The body must be a valid gzip stream that decompresses to the original file
+	gr, err := gzip.NewReader(w.Body)
+	require.NoError(t, err)
+	defer gr.Close()
+	decompressed, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Equal(t, testContent, string(decompressed), "Decompressed body should match the file content")
 }
 
 func TestStaticFileWithoutGzip(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestStaticFileWithGzip` fails on Go 1.27 (`ubuntu-latest @ Go 1.27` job in the **Run Tests** workflow on `master`):

```text
static_test.go:51: "135" is not less than "110"
```

Root cause: the test served a 110-byte file and asserted the gzip body is smaller than the input. Go 1.27's `compress/flate` emits a *stored* (uncompressed) block for this tiny, low-redundancy input, so the gzip stream is 135 bytes. Calling `gzip.NewWriter` directly on the same bytes also yields 135 bytes on Go 1.27 (103 on Go 1.26), so the middleware is behaving correctly and the assertion was relying on an implementation detail of the standard library.

Changes (test only, no production code touched):

- Repeat the sample text 10 times so the input is large and redundant enough that deflate always compresses it, keeping the "compressed is smaller than original" assertion meaningful on every Go version.
- Additionally decompress the response body with `compress/gzip` and assert it equals the original file content. This verifies the stream is valid rather than only checking its size.

## Related issues

- Jira: N/A
- GitHub: N/A (fixes the failing `ubuntu-latest @ Go 1.27` job on `master`)

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: Claude Code (Claude Fable 5.1)
  - **AI-authored files**: `static_test.go`
  - **Human line-by-line reviewed**: None — not yet reviewed by a human.

## Change classification

- [x] Leaf change
- [ ] Core change

Test-only change; no exported API or middleware behavior is modified.

## Plan reference

Goal: make the `Run Tests` workflow green on Go 1.27 without weakening the test. Scope: `static_test.go` only.

## Verification

- **Automated**:
  - `go test ./...` with Go 1.26.7: pass
  - `GOTOOLCHAIN=go1.27.1 go test ./...`: pass (previously failed with `"135" is not less than "110"`)
  - `golangci-lint run ./...` (v2.12.2, repo config): 0 issues
- **Manual**: reproduced the failure on Go 1.27.1 and confirmed `gzip.NewWriter` on the same 110-byte input also produces 135 bytes, which shows the difference comes from the standard library, not from this middleware.
- **Not run**: none

## Security check

- [x] No secrets in the diff
- [ ] External inputs are validated
- [ ] Permission checks are tested
- [ ] Errors do not leak internals
- [x] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: none for users; the test becomes stricter (valid gzip stream and round-trip equality) while no longer depending on deflate's block-selection heuristics.
- **Rollback**: revert this commit.

## Reviewer guide

- **Read carefully**: the new decompress-and-compare block at the end of `TestStaticFileWithGzip`.
- **Spot-check**: the `strings.Repeat` input and the added imports.
