### PR TITLE
fix: match Connection: upgrade case-insensitively

### DIFF
--- a/gzip_test.go
+++ b/gzip_test.go
@@ -715,3 +715,32 @@ http_requests_total{method="get",status="400"} 3 1395066363000`
 		assert.Equal(t, prometheusData, w.Body.String(), "Uncompressed metrics should match original content")
 	}
 }
+
+func TestNoGzipOnConnectionUpgrade(t *testing.T) {
+	tests := []struct {
+		name       string
+		connection string
+	}{
+		{"canonical", "Upgrade"},
+		{"lowercase", "upgrade"},
+		{"uppercase", "UPGRADE"},
+		{"list", "keep-alive, Upgrade"},
+		{"lowercase list", "keep-alive, upgrade"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
+			req.Header.Add(headerAcceptEncoding, "gzip")
+			req.Header.Add("Connection", tt.connection)
+
+			w := httptest.NewRecorder()
+			r := newServer()
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, 200, w.Code)
+			assert.Equal(t, "", w.Header().Get(headerContentEncoding))
+			assert.Equal(t, testResponse, w.Body.String())
+		})
+	}
+}

--- a/handler.go
+++ b/handler.go
@@ -16,6 +16,7 @@ const (
 	headerAcceptEncoding  = "Accept-Encoding"
 	headerContentEncoding = "Content-Encoding"
 	headerVary            = "Vary"
+	headerConnection      = "Connection"
 )
 
 type gzipHandler struct {
@@ -121,7 +122,7 @@ func (g *gzipHandler) Handle(c *gin.Context) {
 
 func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 	if !strings.Contains(req.Header.Get(headerAcceptEncoding), "gzip") ||
-		strings.Contains(req.Header.Get("Connection"), "Upgrade") {
+		connectionHasUpgrade(req.Header) {
 		return false
 	}
 
@@ -134,4 +135,19 @@ func (g *gzipHandler) shouldCompress(req *http.Request) bool {
 	}
 
 	return true
+}
+
+// connectionHasUpgrade reports whether the Connection header lists the
+// "upgrade" token. Connection options are case-insensitive (RFC 7230 6.1,
+// RFC 6455 4.2.1) and proxies may lowercase them, so a plain substring match
+// for "Upgrade" misses WebSocket handshakes that the upgrader still accepts.
+func connectionHasUpgrade(header http.Header) bool {
+	for _, value := range header.Values(headerConnection) {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Connection options are case insensitive (RFC 7230 6.1, RFC 6455 4.2.1). Proxies such as AWS ALB send "upgrade" in lowercase, so the substring match for "Upgrade" let gzip wrap WebSocket handshakes and write the footer to the hijacked connection.

This didn't affect the WebSocket, but causes stray log lines from gin.

Fixes #147